### PR TITLE
Remove ruby version declaration from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,6 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.6.4'
-
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6.0.1'
 # Use sqlite3 as the database for Active Record


### PR DESCRIPTION
## Why was this change made?

Trying to get weekly dependency updates to work

## Was the documentation (README, DevOpsDocs, wiki, openapi.json) updated?

no