### PR TITLE
Run CI tests on master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,11 @@ jobs:
 workflows:
   version: 2
 
-  build:
+  test:
+    jobs:
+    - test
+
+build:
     jobs:
     - build-image:
         filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ workflows:
     jobs:
     - test
 
-build:
+  build:
     jobs:
     - build-image:
         filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,13 +116,6 @@ jobs:
 workflows:
   version: 2
 
-  test:
-    jobs:
-    - test:
-        filters:
-          branches:
-            ignore: master
-
   build:
     jobs:
     - build-image:


### PR DESCRIPTION
This was disabled in the CircleCI config, likely because of copypasta.
